### PR TITLE
Prueba de Rendimiento STM32

### DIFF
--- a/Lab1SdC/.gitignore
+++ b/Lab1SdC/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/Lab1SdC/.vscode/extensions.json
+++ b/Lab1SdC/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/Lab1SdC/include/README
+++ b/Lab1SdC/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/Lab1SdC/lib/README
+++ b/Lab1SdC/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/Lab1SdC/platformio.ini
+++ b/Lab1SdC/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+[env:genericSTM32F103C8]
+platform = ststm32
+board = genericSTM32F103C8
+framework = libopencm3
+debug_tool = stlink

--- a/Lab1SdC/src/main.c
+++ b/Lab1SdC/src/main.c
@@ -1,0 +1,107 @@
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/timer.h>
+#include <libopencm3/cm3/systick.h>
+#include <stdio.h> 
+#include <libopencm3/cm3/nvic.h>
+
+
+#define ITERATIONS 30000000
+
+uint32_t freqclk = 24;
+
+#define UART USART2
+#define UART_PORT GPIOA
+#define UART_TX_PIN GPIO2
+#define UART_RX_PIN GPIO3
+#define UART_BAUDRATE 9600
+#define UART_DATABITS 8
+#define UART_BUFFER_SIZE 64
+
+
+void systemInit(void);
+void configure_usart(void);
+void send_uart(uint32_t time);
+void configure_systick(void);
+
+volatile uint32_t ms_ticks = 0;
+
+void configure_systick(){
+    systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
+    systick_set_reload((freqclk*1000) - 1);
+    systick_interrupt_enable();
+    systick_counter_enable();
+
+}
+void sys_tick_handler(void) {
+    ms_ticks++;
+}
+
+void configure_usart(void)
+{
+
+    rcc_periph_clock_enable(RCC_GPIOA);
+    rcc_periph_clock_enable(RCC_USART2);
+
+    gpio_set_mode(UART_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, UART_TX_PIN | UART_RX_PIN);
+
+    usart_set_baudrate(USART2, UART_BAUDRATE);
+    usart_set_databits(USART2, UART_DATABITS);
+    usart_set_stopbits(USART2, USART_STOPBITS_1);
+    usart_set_mode(USART2, USART_MODE_TX);
+    usart_set_parity(USART2, USART_PARITY_NONE);
+    usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+
+    usart_enable(USART2);
+}
+
+void send_uart(uint32_t time)
+{
+    char buffer[UART_BUFFER_SIZE];
+    snprintf(buffer, sizeof(buffer), "Frecuencia: %02lu [Mhz], Tiempo de ejecucion: %02lu [ms]",freqclk, time);
+    for (char* p = buffer; *p != '\0'; p++)
+    {
+        usart_send_blocking(UART, *p);
+    }
+}
+
+
+void systemInit(void)
+{
+    
+    if(freqclk == 64){
+        rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_HSI_64MHZ]);
+    }
+    else if(freqclk == 48){
+        rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_HSI_48MHZ]);
+    }else{
+        rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_HSI_24MHZ]);
+    }
+   
+}
+
+
+int main(void)
+{
+    systemInit();
+    configure_usart();
+    configure_systick();
+    volatile float sum = 0;
+    volatile float i = 1.5;
+    //volatile uint32_t sum = 0;
+    //volatile uint32_t i = 1;
+    //Bucle que tarda aprox 10 segundos, asumiendo 4 ciclos por iteración.
+    for ( int j = 0; j < ITERATIONS; j++) {
+        sum += i;
+        sum = 0;
+    }
+    
+    send_uart(ms_ticks);
+    
+    return 0;
+    while (1)
+    {
+    }
+    
+}

--- a/Lab1SdC/test/README
+++ b/Lab1SdC/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
# Resumen
En esta PR se encuentra un proyecto de Platform.io con el código utilizado para la implementación del test de rendimiento en una stm32f103c8.

# Test
El test consiste en hacer una suma de números enteros por un lado, permite ir variando la frecuencia para determinar los tiempos de duración de ejecución, al terminar la stm32 reporta el tiempo y frecuencia empleados en cada run vía UART a la computadora. También se hace la misma prueba para suma de números flotantes.

# Como fue probado
Fue testeado experimentalmente con la placa stm32 programada a través del STLINK y un FTDI232 para la transmisión UART.